### PR TITLE
Fix broken links and allow for "./-" when opening manpages

### DIFF
--- a/src/consts.ts
+++ b/src/consts.ts
@@ -15,6 +15,6 @@
 // You should have received a copy of the GNU General Public License
 // along with vscode.manpages.  If not, see <http://www.gnu.org/licenses/>.
 
-export const MAN_COMMAND_REGEX = /([0-9a-zA-Z_\-:+]+)\s?(?:\(?(\w+)\))?/;
+export const MAN_COMMAND_REGEX = /([0-9a-zA-Z_\-:+\.]+)\s?(?:\(?(\w+)\))?/;
 export const MAN_COMMAND_SECTION_REGEX = /^([^(]+)\((\w+)\)?/;
 export const MAN_APROPOS_REGEX = /^(.+\s?\(\w+\))+\s*- (.+$)/;

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -15,6 +15,6 @@
 // You should have received a copy of the GNU General Public License
 // along with vscode.manpages.  If not, see <http://www.gnu.org/licenses/>.
 
-export const MAN_COMMAND_REGEX = /([0-9a-zA-Z_\-:+\.]+)\s?(?:\(?(\w+)\))?/;
+export const MAN_COMMAND_REGEX = /([0-9a-zA-Z_\-.:+]+)\s?(?:\(?(\w+)\))?/;
 export const MAN_COMMAND_SECTION_REGEX = /^([^(]+)\((\w+)\)?/;
 export const MAN_APROPOS_REGEX = /^(.+\s?\(\w+\))+\s*- (.+$)/;

--- a/src/manpageDocument.ts
+++ b/src/manpageDocument.ts
@@ -29,7 +29,8 @@ export default class ManpageDocument {
     }
 
     private extractLinks(content: string) {
-        const re = /([a-zA-Z_]+)\(([\d])\)/gi;
+        // string MAN_COMMAND_REGEX with global flag appended
+        const re = /([0-9a-zA-Z_\-.:+]+)\s?(?:\((\w+)\))/g;
         const lines = content.split('\n');
 
         for (let lineIndex = 0; lineIndex <= lines.length; lineIndex++) {


### PR DESCRIPTION
I fixed the regex so that links including a ./- will also work.